### PR TITLE
Fix issues with html serializer

### DIFF
--- a/d.ts/serialize.d.ts
+++ b/d.ts/serialize.d.ts
@@ -1,2 +1,2 @@
-declare function fromRichText<T>(richText: any[], serialize: (type: string, data: any, text: string | null, children: T[] | null) => T, htmlSerializer: (data: any, text: string) => T): T[];
+declare function fromRichText<T>(richText: any[], serialize: (type: string, data: any, text: string | null, children: T[] | null) => T, htmlSerializer: (data: any, text: string | null, children: T[] | null) => T): T[];
 export default fromRichText;

--- a/src/generic.ts
+++ b/src/generic.ts
@@ -70,7 +70,7 @@ export class Tree implements ITree {
           return a.start - b.start;
         });
         const blockStart = 0;
-        const blockEnd = block.text.length - 1;
+        const blockEnd = block.text.length;
 
         const tail = acc.length > 0 ? acc[acc.length -1] : null;
 
@@ -184,7 +184,7 @@ function customText(text: string, spans: any[] = []): ILeaf[] {
     return new Leaf(span.start, span.end, span.type, span, [], subText(text, span.start, span.end));
   });
 
-  const textLeaf = new Leaf(0, text.length, ElementKind[ElementKind.span], {}, [], text);
+  const textLeaf = new Leaf(0, text.length, ElementKind[ElementKind.span], { type: ElementKind[ElementKind.span] }, [], text);
   const leavesWithText = [textLeaf].concat(leaves);
 
   return (function processLeaves(leaves: ILeaf[]): ILeaf[] {

--- a/src/generic.ts
+++ b/src/generic.ts
@@ -90,12 +90,12 @@ export class Tree implements ITree {
         
         } else if(Element.isListItem(block)) {
           const listItemLeaf = new Leaf(blockStart, blockEnd, block.type, block, sortedCustomItems, subText(block.text, blockStart, blockEnd))
-          const listLeaf = new Leaf(blockStart, blockEnd, ElementKindAsObj.list, {}, [listItemLeaf]);
+          const listLeaf = new Leaf(blockStart, blockEnd, ElementKindAsObj.list, { type: ElementKindAsObj.list }, [listItemLeaf]);
           return acc.concat([listLeaf]);
 
         } else if(Element.isOrderedListItem(block)) {
           const oListItemLeaf = new Leaf(blockStart, blockEnd, block.type, block, sortedCustomItems, subText(block.text, blockStart, blockEnd))
-          const oListLeaf = new Leaf(blockStart, blockEnd, ElementKindAsObj.oList, {}, [oListItemLeaf]);
+          const oListLeaf = new Leaf(blockStart, blockEnd, ElementKindAsObj.oList, { type: ElementKindAsObj.oList }, [oListItemLeaf]);
           return acc.concat([oListLeaf]);
 
         } else {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,6 +1,6 @@
 import { Tree, ITree, ILeaf } from '@root/generic';
 
-function fromRichText<T>(richText: any[], serialize: (type: string, data: any, text: string | null, children: T[] | null) => T, htmlSerializer: (data: any, text: string) => T): T[] {
+function fromRichText<T>(richText: any[], serialize: (type: string, data: any, text: string | null, children: T[] | null) => T, htmlSerializer: (data: any, text: string | null, children: T[] | null) => T): T[] {
   const genericTree = Tree.fromRichText(richText);
   const children: T[] = genericTree.root.children.map((leaf: ILeaf) => {
     return serializeNode<T>(leaf, serialize, htmlSerializer);
@@ -11,7 +11,7 @@ function fromRichText<T>(richText: any[], serialize: (type: string, data: any, t
 function serializeNode<T>(
   node: ILeaf,
   serialize: (type: string, data: any, text: string | null, children: T[] | null) => T,
-  htmlSerializer: (data: any, text?: string) => T
+  htmlSerializer: (data: any, text?: string | null, children?: T[] | null) => T
 ): T {
 
   function exec(node: ILeaf): T {
@@ -19,7 +19,7 @@ function serializeNode<T>(
       return acc.concat([exec(node)]);
     }, []);
 
-    return htmlSerializer && htmlSerializer(node, node.text) ||
+    return htmlSerializer && htmlSerializer(node.raw, node.text, serializedChildren) ||
       serialize(node.type, node.raw, node.text || null, serializedChildren);
   }
   return exec(node);

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -19,7 +19,7 @@ function serializeNode<T>(
       return acc.concat([exec(node)]);
     }, []);
 
-    return htmlSerializer && htmlSerializer(node.raw, node.text, serializedChildren) ||
+    return htmlSerializer && htmlSerializer(node.raw, node.text || null, serializedChildren) ||
       serialize(node.type, node.raw, node.text || null, serializedChildren);
   }
   return exec(node);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,11 +31,7 @@ var config = {
         test: /\.ts$/,
         enforce: 'pre',
         loader: 'ts-loader',
-        exclude: /node_modules/,
-        options: {
-          emitErrors: true,
-          failOnHint: true
-        }
+        exclude: /node_modules/
       },
       {
         test: /\.json$/,


### PR DESCRIPTION
This PR fixes a couple of issues with the html serializer.

- It fixes an issue that cut off the last letter in the node's text
- It now passes the serialized children to the html serializer
- It adds the span, list, & o-list type to their respective raw data so that these types can be serialized
- It removes the deprecated config options for ts-loader