### PR TITLE
Rewrite of the asText function and basic tests

### DIFF
--- a/src/astext.ts
+++ b/src/astext.ts
@@ -1,0 +1,8 @@
+import { RichTextBlock } from './richtext';
+
+function asText(richtext: RichTextBlock[], joinString: string | null | undefined) {
+  const join = typeof joinString === 'string' ? joinString : ' ';
+  return richtext.map(block => block.text).join(join);
+}
+
+export default asText;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,9 @@
+import asText from "./astext";
 import Tree from "./tree";
 import Serialize from "./serialize";
 
 module.exports = {
-  asText: (richtext: any) => {
-    return richtext.reduce((acc: any, block: any) => {
-      return `${acc} ${block.text}`;
-    }, '\n');
-  },
+  asText,
   asTree: Tree.fromRichText,
   serialize: Serialize,
   Elements: Tree.NODE_TYPES,

--- a/test/astext.js
+++ b/test/astext.js
@@ -1,0 +1,55 @@
+const chai = require('chai');
+const chaiSubset = require('chai-subset');
+const PrismicRichText = require('../dist/prismic-richtext.min.js');
+const expect = chai.expect;
+
+chai.use(chaiSubset);
+
+describe('asText', function() {
+  const mock = [
+    { type: 'paragraph', text: 'A > B', spans: [] },
+    { type: 'preformatted', text: '<example>\n  TEST\n</example>', spans: [] },
+    {
+      'type': 'paragraph',
+      'text': 'This is bold and italic and both.',
+      'spans': [
+        {
+          'start': 8,
+          'end': 12,
+          'type': 'strong'
+        },
+        {
+          'start': 17,
+          'end': 23,
+          'type': 'em'
+        },
+        {
+          'start': 28,
+          'end': 32,
+          'type': 'strong'
+        },
+        {
+          'start': 28,
+          'end': 32,
+          'type': 'em'
+        }
+      ]
+    }
+  ];
+
+  context('applying mock object using default join string (undefined)', function() {
+    const result = PrismicRichText.asText(mock);
+
+    it('should join blocks with one whitespace (default)', function() {
+      expect(result).to.equal('A > B <example>\n  TEST\n</example> This is bold and italic and both.');
+    });
+  });
+
+  context('applying mock object and join string "\\n"', function() {
+    const result = PrismicRichText.asText(mock, '\n');
+
+    it('should join blocks with one line break', function() {
+      expect(result).to.equal('A > B\n<example>\n  TEST\n</example>\nThis is bold and italic and both.');
+    });
+  });
+});


### PR DESCRIPTION
I rewrote the `asText` function.

- It should fix issue #7, meaning text strings no longer start with a line break and space.
- It now has its own file (`src/astext.ts`) and is no longer crammed into the index file.
- Now uses proper types for function arguments
- Added a new feature where the user can define how text blocks are joined. If the second argument (`joinString`) is optional and if not used (`null` or `undefined`), the function will behave as before by joining blocks with one whitespace. There are cases where one might want to join text blocks with line breaks, an empty string or anything else.
- A test file was added (`test/astext.ts`) for the `asText` function. It is pretty basic at the moment but better than nothing.
