### PR TITLE
Use null-safe access in processTextBlock

### DIFF
--- a/src/tree.ts
+++ b/src/tree.ts
@@ -161,7 +161,7 @@ function buildTree(text: string, nodes: SpanNode[]): SpanNode[] {
 }
 
 function processTextBlock(block: RichTextBlock): SpanNode[] {
-  const nodes = block.spans.map((span) => {
+  const nodes = (block.spans || []).map((span) => {
     const text = block.text.slice(span.start, span.end);
     return new SpanNode(span.start, span.end, span.type, text, [], span);
   });


### PR DESCRIPTION
This resolves issue #10, which will allow you to render a Rich Text field without any spans in Gatsby.