### PR TITLE
Fix webpack UMD build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,7 @@ var config = {
     library: libraryName,
     libraryTarget: "umd",
     umdNamedDefine: true,
+    globalObject: "typeof self !== 'undefined' ? self : this",
   },
   module: {
     rules: [


### PR DESCRIPTION
Webpack 4's UMD builds are now incompatible with nodejs by default as they expect `window` to be defined. This changes the config to be compatible with the way it worked in V3.

Here is the Webpack issue: https://github.com/webpack/webpack/issues/6522