### PR TITLE
fix: support overlapping spans that extend past the preceding span

### DIFF
--- a/src/asTree.ts
+++ b/src/asTree.ts
@@ -152,14 +152,24 @@ const textNodeSpansToTreeNodeChildren = (
 		for (let j = i; j < mutSpans.length; j++) {
 			const siblingSpan = mutSpans[j];
 
-			if (
-				siblingSpan !== span &&
-				siblingSpan.start >= span.start &&
-				siblingSpan.end <= span.end
-			) {
-				childSpans.push(siblingSpan);
-				mutSpans.splice(j, 1);
-				j--;
+			if (siblingSpan !== span) {
+				if (siblingSpan.start >= span.start && siblingSpan.end <= span.end) {
+					childSpans.push(siblingSpan);
+					mutSpans.splice(j, 1);
+					j--;
+				} else if (
+					siblingSpan.start < span.end &&
+					siblingSpan.end > span.start
+				) {
+					childSpans.push({
+						...siblingSpan,
+						end: span.end,
+					});
+					mutSpans[j] = {
+						...siblingSpan,
+						start: span.end,
+					};
+				}
 			}
 		}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ import {
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
 export type RichTextFunctionSerializer<ReturnType> = (
-	type: typeof RichTextNodeType[keyof typeof RichTextNodeType],
+	type: (typeof RichTextNodeType)[keyof typeof RichTextNodeType],
 	node: RTAnyNode,
 	text: string | undefined,
 	children: ReturnType[],
@@ -135,7 +135,7 @@ export interface Tree {
 
 export interface TreeNode {
 	key: string;
-	type: typeof RichTextNodeType[keyof typeof RichTextNodeType];
+	type: (typeof RichTextNodeType)[keyof typeof RichTextNodeType];
 	text?: string;
 	node: RTAnyNode;
 	children: TreeNode[];

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ import {
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
 export type RichTextFunctionSerializer<ReturnType> = (
-	type: (typeof RichTextNodeType)[keyof typeof RichTextNodeType],
+	type: typeof RichTextNodeType[keyof typeof RichTextNodeType],
 	node: RTAnyNode,
 	text: string | undefined,
 	children: ReturnType[],
@@ -135,7 +135,7 @@ export interface Tree {
 
 export interface TreeNode {
 	key: string;
-	type: (typeof RichTextNodeType)[keyof typeof RichTextNodeType];
+	type: typeof RichTextNodeType[keyof typeof RichTextNodeType];
 	text?: string;
 	node: RTAnyNode;
 	children: TreeNode[];

--- a/test/__fixtures__/overlappedRichText.json
+++ b/test/__fixtures__/overlappedRichText.json
@@ -78,5 +78,21 @@
 				"type": "strong"
 			}
 		]
+	},
+	{
+		"type": "paragraph",
+		"text": "Lorem ipsum dolor sit amet",
+		"spans": [
+			{
+				"start": 6,
+				"end": 17,
+				"type": "em"
+			},
+			{
+				"start": 12,
+				"end": 21,
+				"type": "strong"
+			}
+		]
 	}
 ]

--- a/test/__snapshots__/composeSerializers.test.ts.snap
+++ b/test/__snapshots__/composeSerializers.test.ts.snap
@@ -22,3 +22,25 @@ exports[`composes multiple serializers 1`] = `
   "<iframe width=\\"200\\" height=\\"113\\" src=\\"https://www.youtube.com/embed/nRUZwmSMS8g?feature=oembed\\" frameborder=\\"0\\" allow=\\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\\" allowfullscreen></iframe>",
 ]
 `;
+
+exports[`supports serializers that return undefined 1`] = `
+[
+  "<p>This block has a line<br/>break just before the word \\"break\\"</p>",
+  "<p>Text before with a <span class=\\"label_1\\">multi-block span!</span></p>",
+  "<p>Paragraph</p>",
+  "<p>A paragraph with a <span class=\\"label_1\\">nested</span> label</p>",
+  "<ol><li>First ordered list item</li><li>Second ordered list item</li><li>Third ordered list item</li><li><strong>Bold and <em>now italic</em> but not anymore</strong> value in the <strong>last</strong> list item</li></ol>",
+  "<p>Paragraph</p>",
+  "<ul><li>First list item</li><li>Second list item</li><li>Third list item</li></ul>",
+  "<p>Paragraph</p>",
+  "<p><a href=\\"https://prismic.io\\" target=\\"_blank\\">A web link</a></p>",
+  "<p><a href=\\"linkResolver(YCiU1hUAACQAxfaH)\\">A document link</a></p>",
+  "<p><a href=\\"https://images.prismic.io/gatsby-source-prismic-v4/6234a400-2c25-4165-8b31-b17cfbefa0d2_patrick-robert-doyle-eb8dmXNOGP4-unsplash.jpg?auto=compress,format\\">A media link</a></p>",
+  "<p><a href=\\"https://gatsby-source-prismic-v4.cdn.prismic.io/gatsby-source-prismic-v4/f68daae5-1e36-466d-9d8f-e51175eed7b3_sample.pdf\\">A non-image media link</a></p>",
+  "<p>A paragraph with a <a href=\\"linkResolver(YCiU1hUAACQAxfaH)\\">nested</a> document link</p>",
+  "<p>Paragraph</p>",
+  "<img src=\\"https://prismic-io.s3.amazonaws.com/gatsby-source-prismic-v4/6234a400-2c25-4165-8b31-b17cfbefa0d2_patrick-robert-doyle-eb8dmXNOGP4-unsplash.jpg\\" alt=\\"Alt text\\" />",
+  "<p>Paragraph</p>",
+  "<iframe width=\\"200\\" height=\\"113\\" src=\\"https://www.youtube.com/embed/nRUZwmSMS8g?feature=oembed\\" frameborder=\\"0\\" allow=\\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\\" allowfullscreen></iframe>",
+]
+`;

--- a/test/__snapshots__/composeSerializers.test.ts.snap
+++ b/test/__snapshots__/composeSerializers.test.ts.snap
@@ -23,6 +23,28 @@ exports[`composes multiple serializers 1`] = `
 ]
 `;
 
+exports[`composes serializers that do not support all node types 1`] = `
+[
+  "<p>This block has a line<br/>break just before the word \\"break\\"</p>",
+  "<p>Text before with a <span class=\\"label_1\\">multi-block span!</span></p>",
+  "<p>Paragraph</p>",
+  "<p>A paragraph with a <span class=\\"label_1\\">nested</span> label</p>",
+  "<ol><li>First ordered list item</li><li>Second ordered list item</li><li>Third ordered list item</li><li><strong>Bold and <em>now italic</em> but not anymore</strong> value in the <strong>last</strong> list item</li></ol>",
+  "<p>Paragraph</p>",
+  "<ul><li>First list item</li><li>Second list item</li><li>Third list item</li></ul>",
+  "<p>Paragraph</p>",
+  "<p><a href=\\"https://prismic.io\\" target=\\"_blank\\">A web link</a></p>",
+  "<p><a href=\\"linkResolver(YCiU1hUAACQAxfaH)\\">A document link</a></p>",
+  "<p><a href=\\"https://images.prismic.io/gatsby-source-prismic-v4/6234a400-2c25-4165-8b31-b17cfbefa0d2_patrick-robert-doyle-eb8dmXNOGP4-unsplash.jpg?auto=compress,format\\">A media link</a></p>",
+  "<p><a href=\\"https://gatsby-source-prismic-v4.cdn.prismic.io/gatsby-source-prismic-v4/f68daae5-1e36-466d-9d8f-e51175eed7b3_sample.pdf\\">A non-image media link</a></p>",
+  "<p>A paragraph with a <a href=\\"linkResolver(YCiU1hUAACQAxfaH)\\">nested</a> document link</p>",
+  "<p>Paragraph</p>",
+  "<img src=\\"https://prismic-io.s3.amazonaws.com/gatsby-source-prismic-v4/6234a400-2c25-4165-8b31-b17cfbefa0d2_patrick-robert-doyle-eb8dmXNOGP4-unsplash.jpg\\" alt=\\"Alt text\\" />",
+  "<p>Paragraph</p>",
+  "<iframe width=\\"200\\" height=\\"113\\" src=\\"https://www.youtube.com/embed/nRUZwmSMS8g?feature=oembed\\" frameborder=\\"0\\" allow=\\"accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture\\" allowfullscreen></iframe>",
+]
+`;
+
 exports[`supports serializers that return undefined 1`] = `
 [
   "<p>This block has a line<br/>break just before the word \\"break\\"</p>",

--- a/test/__snapshots__/serialize.test.ts.snap
+++ b/test/__snapshots__/serialize.test.ts.snap
@@ -57,6 +57,7 @@ exports[`handles overlapped styling correctly 1`] = `
   "<p>Lorem ipsum dolor <strong>sit <em>amet</em></strong></p>",
   "<p>Lorem ipsum dolor <strong>sit <em>amet</em></strong></p>",
   "<p>Lorem ipsum dolor <em><strong>sit amet</strong></em></p>",
+  "<p>Lorem <em>ipsum <strong>dolor</strong></em><strong> sit</strong> amet</p>",
 ]
 `;
 
@@ -67,6 +68,7 @@ exports[`handles overlapped styling correctly 2`] = `
   "<p>Lorem ipsum dolor <strong>sit <em>amet</em></strong></p>",
   "<p>Lorem ipsum dolor <strong>sit <em>amet</em></strong></p>",
   "<p>Lorem ipsum dolor <em><strong>sit amet</strong></em></p>",
+  "<p>Lorem <em>ipsum <strong>dolor</strong></em><strong> sit</strong> amet</p>",
 ]
 `;
 

--- a/test/composeSerializers.test.ts
+++ b/test/composeSerializers.test.ts
@@ -32,3 +32,24 @@ it("ignores undefined serializers", () => {
 		serialize(richTextFixtures.en, composeSerializers(undefined, serializer)),
 	).toStrictEqual(serialize(richTextFixtures.en, serializer));
 });
+
+it("composes serializers that do not support all node types", () => {
+	const richTextFixtures = createRichTextFixtures();
+
+	const mapSerializer1 = { ...htmlMapSerializer };
+	delete mapSerializer1.heading1;
+	delete mapSerializer1.heading2;
+
+	const mapSerializer2 = { ...htmlMapSerializer };
+	delete mapSerializer2.heading1;
+
+	// This serializer does not handle `heading1` nodes.
+	const serializer = composeSerializers(
+		wrapMapSerializer(mapSerializer1),
+		wrapMapSerializer(mapSerializer2),
+	);
+
+	const composedSerialization = serialize(richTextFixtures.en, serializer);
+
+	expect(composedSerialization).toMatchSnapshot();
+});


### PR DESCRIPTION
It looks like there is an overlapping spans problem with intersection. 

This overlapping problem should generate (depending on order)
`<p>Lorem <em>ipsum <strong>dolor</strong></em><strong> sit</strong> amet</p>`

But instead, it generated:
`<p>Lorem <em>ipsum dolor</em><strong>dolor sit</strong> amet</p>`


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
<!--- If it resolves an open issue, please link to the issue here. For example "Resolves: #137" -->

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->
