### PR TITLE
feat: define a serializer child type different from its return type

### DIFF
--- a/src/composeSerializers.ts
+++ b/src/composeSerializers.ts
@@ -12,12 +12,15 @@ import { RichTextFunctionSerializer } from "./types";
  *
  * @returns Composed serializer
  */
-export const composeSerializers = <SerializerReturnType>(
+export const composeSerializers = <
+	SerializerReturnType,
+	SerializerChildType = SerializerReturnType,
+>(
 	...serializers: (
-		| RichTextFunctionSerializer<SerializerReturnType>
+		| RichTextFunctionSerializer<SerializerReturnType, SerializerChildType>
 		| undefined
 	)[]
-): RichTextFunctionSerializer<SerializerReturnType> => {
+): RichTextFunctionSerializer<SerializerReturnType, SerializerChildType> => {
 	return (...args) => {
 		for (let i = 0; i < serializers.length; i++) {
 			const serializer = serializers[i];

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,4 +11,6 @@ export type {
 	RichTextFunctionSerializer,
 	RichTextMapSerializer,
 	RichTextMapSerializerFunction,
+	Tree,
+	TreeNode,
 } from "./types";

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -15,21 +15,33 @@ import { asTree } from "./asTree";
  * @returns An array of serialized nodes
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export const serialize = <SerializerReturnType>(
+export const serialize = <
+	SerializerReturnType,
+	SerializerChildType = SerializerReturnType,
+>(
 	richTextField: RichTextField,
-	serializer: RichTextFunctionSerializer<SerializerReturnType>,
+	serializer: RichTextFunctionSerializer<
+		SerializerReturnType,
+		SerializerChildType
+	>,
 ): SerializerReturnType[] => {
-	return serializeTreeNodes<SerializerReturnType>(
+	return serializeTreeNodes<SerializerReturnType, SerializerChildType>(
 		asTree(richTextField).children,
 		serializer,
 	);
 };
 
-const serializeTreeNodes = <T>(
+const serializeTreeNodes = <
+	SerializerReturnType,
+	SerializerChildType = SerializerReturnType,
+>(
 	nodes: TreeNode[],
-	serializer: RichTextFunctionSerializer<T>,
-): T[] => {
-	const serializedTreeNodes: T[] = [];
+	serializer: RichTextFunctionSerializer<
+		SerializerReturnType,
+		SerializerChildType
+	>,
+): SerializerReturnType[] => {
+	const serializedTreeNodes: SerializerReturnType[] = [];
 
 	for (let i = 0; i < nodes.length; i++) {
 		const treeNode = nodes[i];

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,11 +30,11 @@ import {
  * @typeParam ReturnType - Return type of the function serializer
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export type RichTextFunctionSerializer<ReturnType> = (
+export type RichTextFunctionSerializer<ReturnType, ChildType = ReturnType> = (
 	type: (typeof RichTextNodeType)[keyof typeof RichTextNodeType],
 	node: RTAnyNode,
 	text: string | undefined,
-	children: ReturnType[],
+	children: ChildType[],
 	key: string,
 ) => ReturnType | null | undefined;
 
@@ -46,13 +46,14 @@ export type RichTextFunctionSerializer<ReturnType> = (
  */
 export type RichTextMapSerializerFunction<
 	ReturnType,
+	ChildType = ReturnType,
 	Node extends RTAnyNode = RTAnyNode,
 	TextType = string | undefined,
 > = (payload: {
 	type: Node["type"];
 	node: Node;
 	text: TextType;
-	children: ReturnType[];
+	children: ChildType[];
 	key: string;
 }) => ReturnType | null | undefined;
 
@@ -65,66 +66,116 @@ export type RichTextMapSerializerFunction<
  * @typeParam ReturnType - Return type of the map serializer
  * @see Templating rich text and title fields from Prismic {@link https://prismic.io/docs/technologies/templating-rich-text-and-title-fields-javascript}
  */
-export type RichTextMapSerializer<ReturnType> = {
+export type RichTextMapSerializer<ReturnType, ChildType = ReturnType> = {
 	heading1?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTHeading1Node,
 		undefined
 	>;
 	heading2?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTHeading2Node,
 		undefined
 	>;
 	heading3?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTHeading3Node,
 		undefined
 	>;
 	heading4?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTHeading4Node,
 		undefined
 	>;
 	heading5?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTHeading5Node,
 		undefined
 	>;
 	heading6?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTHeading6Node,
 		undefined
 	>;
 	paragraph?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTParagraphNode,
 		undefined
 	>;
 	preformatted?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTPreformattedNode,
 		undefined
 	>;
-	strong?: RichTextMapSerializerFunction<ReturnType, RTStrongNode, string>;
-	em?: RichTextMapSerializerFunction<ReturnType, RTEmNode, string>;
+	strong?: RichTextMapSerializerFunction<
+		ReturnType,
+		ChildType,
+		RTStrongNode,
+		string
+	>;
+	em?: RichTextMapSerializerFunction<ReturnType, ChildType, RTEmNode, string>;
 	listItem?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTListItemNode,
 		undefined
 	>;
 	oListItem?: RichTextMapSerializerFunction<
 		ReturnType,
+		ChildType,
 		RTOListItemNode,
 		undefined
 	>;
-	list?: RichTextMapSerializerFunction<ReturnType, RTListNode, undefined>;
-	oList?: RichTextMapSerializerFunction<ReturnType, RTOListNode, undefined>;
-	image?: RichTextMapSerializerFunction<ReturnType, RTImageNode, undefined>;
-	embed?: RichTextMapSerializerFunction<ReturnType, RTEmbedNode, undefined>;
-	hyperlink?: RichTextMapSerializerFunction<ReturnType, RTLinkNode, string>;
-	label?: RichTextMapSerializerFunction<ReturnType, RTLabelNode, string>;
-	span?: RichTextMapSerializerFunction<ReturnType, RTSpanNode, string>;
+	list?: RichTextMapSerializerFunction<
+		ReturnType,
+		ChildType,
+		RTListNode,
+		undefined
+	>;
+	oList?: RichTextMapSerializerFunction<
+		ReturnType,
+		ChildType,
+		RTOListNode,
+		undefined
+	>;
+	image?: RichTextMapSerializerFunction<
+		ReturnType,
+		ChildType,
+		RTImageNode,
+		undefined
+	>;
+	embed?: RichTextMapSerializerFunction<
+		ReturnType,
+		ChildType,
+		RTEmbedNode,
+		undefined
+	>;
+	hyperlink?: RichTextMapSerializerFunction<
+		ReturnType,
+		ChildType,
+		RTLinkNode,
+		string
+	>;
+	label?: RichTextMapSerializerFunction<
+		ReturnType,
+		ChildType,
+		RTLabelNode,
+		string
+	>;
+	span?: RichTextMapSerializerFunction<
+		ReturnType,
+		ChildType,
+		RTSpanNode,
+		string
+	>;
 };
 
 // Tree

--- a/src/wrapMapSerializer.ts
+++ b/src/wrapMapSerializer.ts
@@ -15,11 +15,20 @@ import {
  *
  * @returns A regular function serializer
  */
-export const wrapMapSerializer = <SerializerReturnType>(
-	mapSerializer: RichTextMapSerializer<SerializerReturnType>,
-): RichTextFunctionSerializer<SerializerReturnType> => {
+export const wrapMapSerializer = <
+	SerializerReturnType,
+	SerializerChildType = SerializerReturnType,
+>(
+	mapSerializer: RichTextMapSerializer<
+		SerializerReturnType,
+		SerializerChildType
+	>,
+): RichTextFunctionSerializer<SerializerReturnType, SerializerChildType> => {
 	return (type, node, text, children, key) => {
-		const tagSerializer: RichTextMapSerializer<SerializerReturnType>[keyof RichTextMapSerializer<SerializerReturnType>] =
+		const tagSerializer: RichTextMapSerializer<
+			SerializerReturnType,
+			SerializerChildType
+		>[keyof RichTextMapSerializer<SerializerReturnType, SerializerChildType>] =
 			mapSerializer[
 				(RichTextReversedNodeType[
 					type as keyof typeof RichTextReversedNodeType


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

> **Note**: This is a WIP! There is a type error in `src/serialize.ts`.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR allows a map or function Rich Text serializer to define its child type differently than its return type.

Using differnt child and return types is necessary when the serialize logic (e.g. `serialize()` or a custom implemenation using `asTree()`) cannot pass its `children` value using the return type. This happens in Svelte.

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐱
