### PR TITLE
feat: accept map serializers in `composeSerializers()`

### DIFF
--- a/src/composeSerializers.ts
+++ b/src/composeSerializers.ts
@@ -1,4 +1,6 @@
-import { RichTextFunctionSerializer } from "./types";
+import { RichTextFunctionSerializer, RichTextMapSerializer } from "./types";
+
+import { wrapMapSerializer } from "./wrapMapSerializer";
 
 /**
  * Takes an array of serializers and returns a serializer applying provided
@@ -14,15 +16,20 @@ import { RichTextFunctionSerializer } from "./types";
  */
 export const composeSerializers = <SerializerReturnType>(
 	...serializers: (
+		| RichTextMapSerializer<SerializerReturnType>
 		| RichTextFunctionSerializer<SerializerReturnType>
 		| undefined
 	)[]
 ): RichTextFunctionSerializer<SerializerReturnType> => {
 	return (...args) => {
 		for (let i = 0; i < serializers.length; i++) {
-			const serializer = serializers[i];
+			let serializer = serializers[i];
 
 			if (serializer) {
+				if (typeof serializer === "object") {
+					serializer = wrapMapSerializer(serializer);
+				}
+
 				const res = serializer(...args);
 
 				if (res != null) {

--- a/test/composeSerializers.test.ts
+++ b/test/composeSerializers.test.ts
@@ -14,7 +14,7 @@ it("composes multiple serializers", () => {
 	const mapSerializer2 = { heading1: htmlMapSerializer.heading1 };
 
 	const serializer = composeSerializers(
-		wrapMapSerializer(mapSerializer1),
+		mapSerializer1,
 		wrapMapSerializer(mapSerializer2),
 	);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Chore (a non-breaking change which is related to package maintenance)
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Description

This PR updates `composeSerializers()` to accept map serializers. The change simplifies how map and function serializers can be composed.

Before this PR:

```ts
import { composeSerializers, wrapMapSerializer } from "@prismicio/richtext";

const serializer = composeSerializers(
  wrapMapSerializer(myMapSerializer),
  myFunctionSerializer
);
```

After this PR:

```ts
import { composeSerializers } from "@prismicio/richtext";

const serializer = composeSerializers(myMapSerializer, myFunctionSerializer);
```

## Checklist:

<!--- Put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires an update to the official documentation.
- [x] All [TSDoc](https://tsdoc.org) comments are up-to-date and new ones have been added where necessary.
- [x] All new and existing tests are passing.

<!--- A cute animal (or car) picture is welcome to close your PR! -->

🐻‍❄️
